### PR TITLE
fix missing typedef

### DIFF
--- a/lib/src/custom_sliver_animated_list.dart
+++ b/lib/src/custom_sliver_animated_list.dart
@@ -3,6 +3,13 @@ import 'package:flutter/material.dart';
 
 const Duration _kDuration = Duration(milliseconds: 300);
 
+typedef AnimatedListItemBuilder = Widget Function(
+    BuildContext context, int index, Animation<double> animation);
+
+typedef AnimatedListRemovedItemBuilder = Widget Function(
+    BuildContext context, Animation<double> animation);
+
+
 class CustomSliverAnimatedList extends StatefulWidget {
   /// Creates a sliver that animates items when they are inserted or removed.
   const CustomSliverAnimatedList({


### PR DESCRIPTION
Solves this build error:

Error (Xcode): ../../../../.pub-cache/git/animated_list-c12c6985575c7fa1325e8aece134e69afd328cd3/lib/src/custom_sliver_animated_list.dart:28:9: Error: Type
'AnimatedListItemBuilder' not found.

and this one 

Error (Xcode): ../../../../.pub-cache/git/animated_list-c12c6985575c7fa1325e8aece134e69afd328cd3/lib/src/custom_sliver_animated_list.dart:219:5: Error: Type
'AnimatedListRemovedItemBuilder' not found.